### PR TITLE
Add system with StandardLoad

### DIFF
--- a/src/library/psitest_library.jl
+++ b/src/library/psitest_library.jl
@@ -114,7 +114,7 @@ function build_c_sys5_ml(; kwargs...)
         end
     end
     line = PSY.get_component(Line, c_sys5_ml, "1")
-    PSY.convert_component!(MonitoredLine, line, c_sys5_ml)
+    PSY.convert_component!(c_sys5_ml, line, MonitoredLine)
     return c_sys5_ml
 end
 
@@ -4122,6 +4122,6 @@ function build_c_sys5_all_components(; kwargs...)
     # TODO: should I handle add_reserves? build_c_sys5_hy_uc doesn't
 
     bus3 = PSY.get_component(PowerLoad, c_sys5_all_components, "Bus3")
-    PSY.convert_component!(StandardLoad, bus3, c_sys5_all_components)
+    PSY.convert_component!(c_sys5_all_components, bus3, StandardLoad)
     return c_sys5_all_components
 end

--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -1200,4 +1200,11 @@ const SYSTEM_CATALOG = [
         raw_data = joinpath(DATA_DIR, "psid_tests", "data_examples", "Omib_Load.raw"),
         build_function = build_psid_load_tutorial_droop,
     ),
+    SystemDescriptor(;
+        name = "c_sys5_all_components",
+        description = "5-Bus system with 5-Bus system with Renewable Energy, Hydro Energy Reservoir, and both StandardLoad and PowerLoad",
+        category = PSITestSystems,
+        raw_data = joinpath(DATA_DIR, "psy_data", "data_5bus_pu.jl"),
+        build_function = build_c_sys5_all_components,
+    ),
 ]

--- a/test/test_psitestsystems.jl
+++ b/test/test_psitestsystems.jl
@@ -28,3 +28,17 @@
         end
     end
 end
+
+@testset "Test PSI Cases' Specific Behaviors" begin
+    """
+    Make sure c_sys5_all_components has both a PowerLoad and a StandardLoad, as guaranteed
+    """
+    function test_c_sys5_all_components()
+        sys = build_system(PSITestSystems, "c_sys5_all_components"; force_build = true)
+        @test length(PSY.get_components(PSY.StaticLoad, sys)) >= 2
+        @test length(PSY.get_components(PSY.PowerLoad, sys)) >= 1
+        @test length(PSY.get_components(PSY.StandardLoad, sys)) >= 1
+        println((PSY.get_components(PSY.StaticLoad, sys)))
+    end
+    test_c_sys5_all_components()
+end


### PR DESCRIPTION
Useful for testing in PowerAnalytics. NOTE: depends on https://github.com/NREL-Sienna/PowerSystems.jl/pull/1022.
---
 - Add `c_sys5_all_components`, which includes renewable energy, hydro energy reservoir, and both `StandardLoad` and `PowerLoad`
 - Include some basic tests
 - NOTE: depends on a `convert_component!` method in PowerSystems that I just added