### PR TITLE
Add option to manually override data directory

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1,5 +1,33 @@
 const PACKAGE_DIR = joinpath(dirname(dirname(pathof(PowerSystemCaseBuilder))))
-const DATA_DIR = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-2.0")
+const DATA_DIR_KEY = "PSB_DATA_DIR"  # Environment variable to check for data directory
+
+# Gets evaluated at compile time to find the data directory. To re-evaluate, force
+# recompilation with `Base.compilecache(Base.identify_package("PowerSystemCaseBuilder"))`
+function get_data_dir()
+    if haskey(ENV, DATA_DIR_KEY)
+        candidate = ENV[DATA_DIR_KEY]
+        if isdir(candidate)
+            @debug "Using PSB data dir $candidate from environment variable"
+            return candidate
+        else
+            error(
+                "The directory specified by the environment variable $DATA_DIR_KEY, $candidate, does not exist.",
+            )
+        end
+    else
+        candidate = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-2.0")
+        if isdir(candidate)
+            @debug "Using default PSB data dir $candidate"
+            return candidate
+        else
+            error(
+                "No data dir specified by environment variable $DATA_DIR_KEY, and the default, $candidate, does not exist.",
+            )
+        end
+    end
+end
+
+const DATA_DIR = get_data_dir()
 const RTS_DIR = joinpath(LazyArtifacts.artifact"rts", "RTS-GMLC-0.2.2")
 
 const SYSTEM_DESCRIPTORS_FILE = joinpath(PACKAGE_DIR, "src", "system_descriptor.jl")

--- a/test/test_definitions.jl
+++ b/test/test_definitions.jl
@@ -1,0 +1,17 @@
+@testset "Test data directory configuration" begin
+    td = mktempdir()
+    withenv(PSB.DATA_DIR_KEY => td) do
+        the_data_dir = PSB.get_data_dir()
+        @test isdir(the_data_dir)
+        @test the_data_dir == td
+    end
+    withenv(PSB.DATA_DIR_KEY => joinpath(td, "DNE")) do
+        @test_throws ErrorException PSB.get_data_dir()
+    end
+    withenv(PSB.DATA_DIR_KEY => nothing) do
+        the_data_dir = PSB.get_data_dir()
+        @test isdir(the_data_dir)
+        @test occursin("PowerSystemsTestData-2.0", the_data_dir)
+    end
+    @test isdir(PSB.DATA_DIR)
+end


### PR DESCRIPTION
Fixes https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl/issues/54. Here I have opted to check for the environment variable at the point where the existing `const DATA_DIR` is defined. This gets bound up in the precompilation such that if a user wants to redefine the data directory after precompilation, they would have to manually re-compile with `Base.compilecache(Base.identify_package("PowerSystemCaseBuilder"))`. If that is acceptable, I'll go ahead and write the documentation for how to use this new feature. If not, we will probably have to replace uses of `DATA_DIR` with calls to a function that checks the environment variable each time; I am not opposed to this but I thought I'd be conservative with my first pass.