### PR TITLE
Variable Cost Refactor Part 2: PowerSimulations

### DIFF
--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -1465,7 +1465,7 @@ function _duplicate_system(main_sys::PSY.System, twin_sys::PSY.System, HVDC_line
             if ix ∈ [1, length(old_pwl_array)]
                 noise_val, rand_ix = iterate(noise_values, rand_ix)
                 cost_noise = 50.0 * noise_val
-                new_pwl_array[ix] = (x, (y + cost_noise))
+                new_pwl_array[ix] = (x = x, y = (y + cost_noise))
             else
                 try_again = true
                 while try_again
@@ -1474,12 +1474,12 @@ function _duplicate_system(main_sys::PSY.System, twin_sys::PSY.System, HVDC_line
                     noise_val, rand_ix = iterate(noise_values, rand_ix)
                     power_noise = 0.01 * noise_val
                     slope_previous =
-                        ((y + cost_noise) - old_pwl_array[ix - 1][1]) /
-                        ((x - power_noise) - old_pwl_array[ix - 1][2])
+                        ((y + cost_noise) - old_pwl_array[ix - 1].y) /
+                        ((x - power_noise) - old_pwl_array[ix - 1].x)
                     slope_next =
-                        (-(y + cost_noise) + old_pwl_array[ix + 1][1]) /
-                        (-(x - power_noise) + old_pwl_array[ix + 1][2])
-                    new_pwl_array[ix] = ((x - power_noise), (y + cost_noise))
+                        (-(y + cost_noise) + old_pwl_array[ix + 1].y) /
+                        (-(x - power_noise) + old_pwl_array[ix + 1].x)
+                    new_pwl_array[ix] = (x = (x - power_noise), y = (y + cost_noise))
                     try_again = slope_previous > slope_next
                     if rand_ix == length(noise_values)
                         break


### PR DESCRIPTION
The second part of a significant refactor of Sienna cost data structures (part 1 is [here](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1056#issuecomment-1959057500)). The main focus here is to bring PowerSimulations.jl up to date with the elimination of `VariableCost` in favor of `FunctionData`. That entails these changes in PowerSystemCaseBuilder:

- Accommodate `PiecewiseLinearPointData` now using `NamedTuple`s

Tests pass:
<img width="1635" alt="Screenshot 2024-02-26 at 4 32 27 AM" src="https://github.com/NREL-Sienna/InfrastructureSystems.jl/assets/23368820/8c27f79b-1f06-4a81-8344-1a78e4ef76ad">
