### PR TITLE
update(PowerSystemTestData): Updating tag number of PowerSystemTestData.

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,10 @@
 [CaseData]
-git-tree-sha1 = "2b7013812a985ce5884696ce276ca17b2719a57a"
+git-tree-sha1 = "e72e0ad2722dc7be918ec2879d80adedb4d65576"
 lazy = true
 
     [[CaseData.download]]
-    url = "https://github.com/NREL-Sienna/PowerSystemsTestData/archive/refs/tags/2.0.tar.gz"
-    sha256 = "cb15bf019cc1a187e430d4fe0db9c000decf07dc2cdccc6c1b53b07b136fa41c"
+    url = "https://github.com/NREL-Sienna/PowerSystemsTestData/archive/refs/tags/2.1.tar.gz"
+    sha256 = "6813e5f4c3aaf0ac0072ce81fefa4a3f7b0804b7464a04f2d89a6f2c48c95658"
 
 [rts]
 git-tree-sha1 = "5098f357bad765bfefcff58f080818863ca776bd"

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1,5 +1,5 @@
 const PACKAGE_DIR = joinpath(dirname(dirname(pathof(PowerSystemCaseBuilder))))
-const DATA_DIR = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-2.0")
+const DATA_DIR = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-2.1")
 const RTS_DIR = joinpath(LazyArtifacts.artifact"rts", "RTS-GMLC-0.2.2")
 
 const SYSTEM_DESCRIPTORS_FILE = joinpath(PACKAGE_DIR, "src", "system_descriptor.jl")


### PR DESCRIPTION
List of changes:
- Updated git-tree-sha1, url and sha256 to reflect update on PowerSystemTestData

Related:
- https://github.com/NREL-Sienna/PowerSystemsTestData/pull/51#event-12297340920
- https://github.com/NREL-Sienna/PowerSystemsTestData/releases/tag/2.1