### PR TITLE
Fix c_sys5_hybrid_uc case

### DIFF
--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -1291,7 +1291,6 @@ function _duplicate_system(main_sys::PSY.System, twin_sys::PSY.System, HVDC_line
 
         IS.assign_new_uuid!(twin_sys.data, b)
         PSY.remove_component!(twin_sys, b)
-        b.time_series_container = IS.TimeSeriesContainer()
         # change name
         PSY.set_name!(b, name_ * "_twin")
         # create new component from scratch since copying is not working

--- a/src/library/psitest_library.jl
+++ b/src/library/psitest_library.jl
@@ -3130,6 +3130,7 @@ function build_c_sys5_hybrid_uc(; kwargs...)
     thermals = thermal_generators5(nodes)
     loads = loads5(nodes)
     renewables = renewable_generators5(nodes)
+    branches = branches5(nodes)
     _battery(nodes, bus, name) = PSY.BatteryEMS(;
         name = name,
         prime_mover_type = PrimeMovers.BA,
@@ -3179,10 +3180,10 @@ function build_c_sys5_hybrid_uc(; kwargs...)
     c_sys5_hybrid = PSY.System(
         100.0,
         nodes,
-        thermal_generators5(nodes),
-        renewable_generators5(nodes),
-        loads5(nodes),
-        branches5(nodes);
+        thermals,
+        renewables,
+        loads,
+        branches;
         time_series_in_memory = get(sys_kwargs, :time_series_in_memory, true),
         sys_kwargs...,
     )


### PR DESCRIPTION
Ensure that the System and HybridSystem have the same components rather than copies.