### PR TITLE
Fix `RTS_GMLC_RT_sys` horizon

### DIFF
--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -430,7 +430,7 @@ function build_RTS_GMLC_RT_sys(; raw_data, kwargs...)
     resolution = get(sys_kwargs, :time_series_resolution, Dates.Minute(5))
     sys = PSY.System(rawsys; time_series_resolution = resolution, sys_kwargs...)
     interval = get(sys_kwargs, :interval, Dates.Minute(5))
-    horizon = Hour(get(sys_kwargs, :horizon, 24))
+    horizon = Hour(get(sys_kwargs, :horizon, 2))
     PSY.transform_single_time_series!(sys, horizon, interval)
     return sys
 end

--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -310,7 +310,7 @@ function build_5_bus_hydro_ed_sys(; raw_data, kwargs...)
         time_series_in_memory = true,
         sys_kwargs...,
     )
-    PSY.transform_single_time_series!(c_sys5_hy_ed, Hour(12), Hour(1))
+    PSY.transform_single_time_series!(c_sys5_hy_ed, Hour(2), Hour(1))
 
     return c_sys5_hy_ed
 end
@@ -338,7 +338,7 @@ function build_5_bus_hydro_ed_sys_targets(; raw_data, kwargs...)
     for hy in get_components(HydroEnergyReservoir, c_sys5_hy_ed)
         set_operation_cost!(hy, cost)
     end
-    PSY.transform_single_time_series!(c_sys5_hy_ed, Hour(12), Hour(1))
+    PSY.transform_single_time_series!(c_sys5_hy_ed, Hour(2), Hour(1))
 
     return c_sys5_hy_ed
 end
@@ -621,7 +621,7 @@ end
 
 function build_modified_RTS_GMLC_RT_sys(; kwargs...)
     sys = build_modified_RTS_GMLC_realization_sys(; kwargs...)
-    PSY.transform_single_time_series!(sys, Hour(12), Minute(15))
+    PSY.transform_single_time_series!(sys, Hour(1), Minute(15))
     return sys
 end
 


### PR DESCRIPTION
In PSY3, a time series' horizon was specified as a multiple of its resolution; in PSY4 it's its own `TimePeriod`. Within `build_RTS_GMLC_RT_sys`, the horizon of 24 was incorrectly migrated to 24 hours rather than to 24*(5 minute resolution) = 2 hours.

This may be my smallest ever pull request. Several hours of head scratching went into that one deleted character….