### PR TITLE
Add WECC 9 Bus system from Sauer and Pai

### DIFF
--- a/src/library/psid_library.jl
+++ b/src/library/psid_library.jl
@@ -62,6 +62,92 @@ function build_3bus_inverter(; raw_data, kwargs...)
     return sys
 end
 
+function build_psid_wecc_9_dynamic(; raw_data, kwargs...)
+    sys_kwargs = filter_kwargs(; kwargs...)
+    sys = System(raw_data; runchecks = false, sys_kwargs...)
+
+    # Manually change reactance of three branches to match Sauer & Pai (2007) Figure 7.4
+    set_x!(get_component(Branch, sys, "Bus 5-Bus 4-i_1"), 0.085)
+    set_x!(get_component(Branch, sys, "Bus 9-Bus 6-i_1"), 0.17)
+    set_x!(get_component(Branch, sys, "Bus 7-Bus 8-i_1"), 0.072)
+
+    # Loads from raw file are constant power, consistent with Sauer & Pai (p169)
+
+    ############### Data Dynamic devices ########################
+
+    # --- Machine models ---
+    # All parameters are from Sauer & Pai (2007) Table 7.3 M/C columns 1,2,3
+    function machine_sauerpai(i)
+        R = [0.0, 0.0, 0.0] # <-- not specified in Table 7.3
+        Xd = [0.146, 0.8958, 1.3125]
+        Xq = [0.0969, 0.8645, 1.2578]
+        Xd_p = [0.0608, 0.1198, 0.1813]
+        Xq_p = [0.0969, 0.1969, 0.25]
+        Td0_p = [8.96, 6.0, 5.89]
+        Tq0_p = [0.31, 0.535, 0.6]
+        return PSY.OneDOneQMachine(;
+            R = R[i],
+            Xd = Xd[i],
+            Xq = Xq[i],
+            Xd_p = Xd_p[i],
+            Xq_p = Xq_p[i],
+            Td0_p = Td0_p[i],
+            Tq0_p = Tq0_p[i],
+        )
+    end
+
+    # --- Shaft models ---
+    # All parameters are from Sauer & Pai (2007)
+    function shaft_sauerpai(i)
+        D_M = [0.1, 0.2, 0.3] # D/M from bottom of p165
+        H = [23.64, 6.4, 3.01] # H from Table 7.3
+        D = (2 * D_M .* H) / get_frequency(sys)
+        return PSY.SingleMass(;
+            H = H[i],
+            D = D[i],
+        )
+    end
+
+    # --- AVR models ---
+    # All parameters are from Sauer & Pai (2007) Table 7.3 exciter columns 1,2,3
+    # All S&P exciters are IEEE-Type I (p165)
+    # NOTE: In S&P, terminal voltage seen by AVR is same as the bus voltage.
+    #  In AVRTypeI, it is a measurement if the bus voltage with a sampling rate. 
+    #  Thus, Tr is set to be very small to account for this difference.
+    avr_typei() = PSY.AVRTypeI(;
+        Ka = 20,
+        Ke = 1.0,
+        Kf = 0.063,
+        Ta = 0.2,
+        Te = 0.314,
+        Tf = 0.35,
+        Tr = 0.0001, # <-- not specified in Table 7.3
+        Va_lim = (-0.5, 0.5), # <-- not specified in Table 7.3 
+        Ae = 0.0039,
+        Be = 1.555,
+    )
+
+    function dyn_gen_sauerpai(generator)
+        i = get_number(get_bus(generator))
+        return PSY.DynamicGenerator(;
+            name = PSY.get_name(generator),
+            ω_ref = 1.0,
+            machine = machine_sauerpai(i),
+            shaft = shaft_sauerpai(i),
+            avr = avr_typei(),
+            prime_mover = tg_none(),
+            pss = pss_none(),
+        )
+    end
+
+    for g in get_components(Generator, sys)
+        case_gen = dyn_gen_sauerpai(g)
+        add_component!(sys, case_gen, g)
+    end
+
+    return sys
+end
+
 ##################################
 # Add Load tutorial systems here #
 ##################################

--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -1719,6 +1719,13 @@ const SYSTEM_CATALOG = [
         build_function = build_3bus_inverter,
     ),
     SystemDescriptor(;
+        name = "WECC 9 Bus",
+        description = "WECC 9 Bus System with dynamic gens from Sauer and Pai",
+        category = PSIDSystems,
+        raw_data = joinpath(DATA_DIR, "psid_tests", "data_tests", "WSCC 9 bus.raw"),
+        build_function = build_psid_wecc_9_dynamic,
+    ),
+    SystemDescriptor(;
         name = "2 Bus Load Tutorial",
         description = "2 Bus Base System for load tutorials",
         category = PSIDSystems,


### PR DESCRIPTION
## Summary
New library model intended to be as close as possible to the WECC 9 bus system with dynamic generators defined in Chapter 7 of [Sauer & Pai 2007](https://courses.physics.illinois.edu/ece576/sp2018/Sauer%20and%20Pai%20book%20-%20Jan%202007.pdf) (S&P). I added inline comments that trace back to figures, tables, and page numbers. 
- [x] All tests in `test/` passed.
- [x] Ran the formatter.
## Usage 
```julia
using PowerSystemCaseBuilder
sys = build_system(PSIDSystems, "WECC 9 Bus")
```
## Validation
- The admittance matrix of this model is identical to S&P Table 7.2.
- The AC powerflow of this model is identical to S&P Table 7.1.
- The eigenvalues of this model are roughly equivalent to S&P Table 8.2 (see Question 3 below).
## Implementation
### Network details
- Base static model was already available  in [`PowerSystemsTestData`](https://github.com/NREL-Sienna/PowerSystemsTestData/blob/master/psid_tests/data_tests/WSCC%209%20bus.raw) (originally from [here](https://icseg.iti.illinois.edu/wscc-9-bus-system/)).
- Changed three branch reactances so they would match the S&P model in S&P Figure 7.2. 
### Dynamic generator details
- **Machine** parameters from S&P Table 7.3. Defined custom `OneDOneQMachine` instances.
- **Shaft** parameters from S&P Table 7.3 and the bottom of p165. Defined custom `SingleMass` instances.
- **AVR** parameters from S&P Table 7.3. Defined custom `AVRTypeI` instance.
- No **TurbineGov** or **PSS** models (consistent with S&P).
## Questions
1. Feedback on **name**? Chose `WECC 9 Bus` to be similar to `WECC 240 Bus`, but there were a lot of conventions to choose from.
2. Feedback on **category**? Chose `PSIDSystems` since this is a well known model from a textbook. Other option would be `PSIDTestSystems`, but thought that was for testing PSID itself. 
3. I did not put my validation tests (admittance, powerflow, eigenvalues) in this repo because I don't think they belong here. Should I put them in one of [these](https://github.com/NREL-Sienna/PowerSimulationsDynamics.jl/blob/main/test/test_case21_gast.jl) instead? My eigenvalues aren't perfect, so might be nice to quantify how off they are by creating a `@test` that only passes with a larger tolerance. Metric in title is norm of complex difference.

    <img src="https://github.com/user-attachments/assets/ec0c0f50-5304-4f6a-9b13-af7e153d186e" width="400"/>