### PR TITLE
Update system_descriptor_data.jl to include case5_pjm

### DIFF
--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -979,6 +979,13 @@ const SYSTEM_CATALOG = [
         build_function = build_matpower,
     ),
     SystemDescriptor(;
+        name = "matpower_case5_pjm_sys",
+        description = "Original Matpower Test system",
+        category = MatpowerTestSystems,
+        raw_data = joinpath(DATA_DIR, "matpower", "case5_pjm.m"),
+        build_function = build_matpower,
+    ),
+    SystemDescriptor(;
         name = "matpower_case5_sys",
         description = "Matpower Test system",
         category = MatpowerTestSystems,


### PR DESCRIPTION
adds system descriptor data for the original case5 system from [MATPOWER](https://matpower.org/docs/ref/matpower5.0/case5.html)