### PR TITLE
Use consistent generators in test_RTS_GMLC_sys

### DIFF
--- a/src/library/psitest_library.jl
+++ b/src/library/psitest_library.jl
@@ -2669,7 +2669,8 @@ function build_test_RTS_GMLC_sys(; raw_data, add_forecasts, kwargs...)
         rawsys = PSY.PowerSystemTableData(
             raw_data,
             100.0,
-            joinpath(raw_data, "user_descriptors.yaml"),
+            joinpath(raw_data, "user_descriptors.yaml");
+            generator_mapping_file = joinpath(raw_data, "generator_mapping.yaml"),
         )
         sys = PSY.System(rawsys; time_series_resolution = Dates.Hour(1), sys_kwargs...)
         return sys


### PR DESCRIPTION
The build function for test_RTS_GMLC_sys was using different generator mappings based on the add_forecasts flag. This resulted in different generator types in the system when the default generator mapping was different from the mapping in this repository.

@pesap @jd-lara Please confirm my assumptions about this being a bug.