### PR TITLE
new system for radial/series reduction testing

### DIFF
--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -1648,6 +1648,13 @@ const SYSTEM_CATALOG = [
         build_function = build_batt_test_case_f_sys,
     ),
     SystemDescriptor(;
+        name = "case10_radial_series_reductions",
+        description = "Test system for radial and series reductions",
+        category = PSITestSystems,
+        raw_data = joinpath(DATA_DIR, "psse_raw", "case10_radial_series_reductions.raw"),
+        build_function = build_pti,
+    ),
+    SystemDescriptor(;
         name = "case11_network_reductions",
         description = "Test system for building simulations with network reductions",
         category = PSITestSystems,


### PR DESCRIPTION
As requested in PNM [PR #184](https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/pull/184), add a test case where each of: 3WT arcs, parallel branches are involved in each of: radial, degree 2 reduction.

Requires [PR #105](https://github.com/NREL-Sienna/PowerSystemsTestData/pull/105) in PSTD.