### PR TITLE
Add converged case16 with all network components

### DIFF
--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -1361,6 +1361,13 @@ const SYSTEM_CATALOG = [
         build_function = build_pti,
     ),
     SystemDescriptor(;
+        name = "pti_case16_complete_sys",
+        description = "PSSE Case 16 with All Network Components",
+        category = PSSEParsingTestSystems,
+        raw_data = joinpath(DATA_DIR, "psse_raw", "case16_all_components.raw"),
+        build_function = build_pti,
+    ),
+    SystemDescriptor(;
         name = "pti_case11_with_synchronous_condensers_sys",
         description = "PSSE Case 11 with Synch. Condensers",
         category = PSSEParsingTestSystems,


### PR DESCRIPTION
This system is used for testing the roundtrip in PFs, using all parsed network components available