### PR TITLE
Add all_systems() function

### DIFF
--- a/src/PowerSystemCaseBuilder.jl
+++ b/src/PowerSystemCaseBuilder.jl
@@ -17,6 +17,7 @@ export PSISystems
 export PSIDSystems
 export SPISystems
 
+export all_systems
 export build_system
 export list_categories
 export show_categories

--- a/src/system_catalog.jl
+++ b/src/system_catalog.jl
@@ -64,6 +64,38 @@ function list_systems(catalog::SystemCatalog, category::Type{<:SystemCategory})
     end
 end
 
+"""
+Builds all [`PowerSystems.System`](@extref)s in the [`SystemCatalog`](@ref) and returns them
+as a `Dict` keyed by `(category, system_name)` tuples.
+
+Systems that require additional keyword arguments are built with their default arguments
+where available. Systems that fail to build are skipped with a warning.
+
+# Accepted Key Words
+- `system_catalog::SystemCatalog`: Defaults to the `PowerSystemCaseBuilder.jl` catalog of
+  `System`s
+- All other keyword arguments are forwarded to [`build_system`](@ref)
+"""
+function all_systems(;
+    system_catalog::SystemCatalog = SystemCatalog(),
+    kwargs...,
+)
+    result = Dict{Tuple{DataType, String}, PSY.System}()
+    for category in list_categories(system_catalog)
+        for name in list_systems(system_catalog, category)
+            try
+                result[(category, name)] = build_system(
+                    category, name; system_catalog = system_catalog, kwargs...,
+                )
+            catch e
+                @warn "Skipping system $(category)/$(name)" exception =
+                    (e, catch_backtrace())
+            end
+        end
+    end
+    return result
+end
+
 function SystemCatalog(system_catalogue::Array{SystemDescriptor} = SYSTEM_CATALOG)
     data = Dict{DataType, Dict{String, SystemDescriptor}}()
     unique_names = Set{String}()

--- a/src/system_catalog.jl
+++ b/src/system_catalog.jl
@@ -88,6 +88,7 @@ function all_systems(;
                     category, name; system_catalog = system_catalog, kwargs...,
                 )
             catch e
+                e isa ErrorException || rethrow()
                 @warn "Skipping system $(category)/$(name)" exception =
                     (e, catch_backtrace())
             end

--- a/test/test_all_systems.jl
+++ b/test/test_all_systems.jl
@@ -6,10 +6,12 @@
     @test sys isa PSY.System
 
     # Test that all_systems returns a dict with the expected type
-    small_descriptor = PSB.SYSTEM_CATALOG[findfirst(
+    idx = findfirst(
         d -> PSB.get_category(d) == category && PSB.get_name(d) == name,
         PSB.SYSTEM_CATALOG,
-    )]
+    )
+    @test idx !== nothing
+    small_descriptor = PSB.SYSTEM_CATALOG[something(idx)]
     small_catalog = SystemCatalog([small_descriptor])
     result = all_systems(; system_catalog = small_catalog)
     @test result isa Dict{Tuple{DataType, String}, PSY.System}

--- a/test/test_all_systems.jl
+++ b/test/test_all_systems.jl
@@ -1,0 +1,19 @@
+@testset "all_systems" begin
+    # Test with a minimal catalog containing just one system
+    category = MatpowerTestSystems
+    name = first(list_systems(category))
+    sys = build_system(category, name)
+    @test sys isa PSY.System
+
+    # Test that all_systems returns a dict with the expected type
+    small_descriptor = PSB.SYSTEM_CATALOG[findfirst(
+        d -> PSB.get_category(d) == category && PSB.get_name(d) == name,
+        PSB.SYSTEM_CATALOG,
+    )]
+    small_catalog = SystemCatalog([small_descriptor])
+    result = all_systems(; system_catalog = small_catalog)
+    @test result isa Dict{Tuple{DataType, String}, PSY.System}
+    @test length(result) == 1
+    @test haskey(result, (category, name))
+    @test result[(category, name)] isa PSY.System
+end


### PR DESCRIPTION
## Summary
- Adds exported `all_systems()` function that builds every system in the catalog and returns a `Dict{Tuple{DataType, String}, PSY.System}`
- Systems that fail to build (e.g., those requiring specific kwargs like `avr_type`) are skipped with a warning
- Adds test for the new function

Closes #178

## Test plan
- [x] `test_all_systems` passes: verifies return type, length, and contents using a single-system catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)