### PR TITLE
Add PSSE controlled TapTransformer test systems (v33 and v35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ $RECYCLE.BIN/
 
 ## Acknowledgements
 # Many thanks to `https://gitignore.io/`, written and maintained by Joe Blau, which contributed much material to this gitignore file.
+
+# Claude
+hooks
+settings.*.json
+settings.json

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,10 @@
 [CaseData]
-git-tree-sha1 = "4cf1aa00f73fcd77b6f2603c38f3e1eddb6e88fc"
+git-tree-sha1 = "c33ea1792d4054033464aad6d48a2ed199b73460"
 lazy = true
 
     [[CaseData.download]]
     url = "https://github.com/Sienna-Platform/PowerSystemsTestData/archive/refs/tags/4.0.4.tar.gz"
-    sha256 = "e02f3b62cc0ada5e82c2506665ca284d969bedecd1962137811854b54f97f80f"
+    sha256 = "495397fbb54511801113688e27e3af0e5a7a737edb81eaaa8b8af868b2bf1f54"
 
 [rts]
 git-tree-sha1 = "c257b2c37b981f261fdc328b0fb9b96436a96537"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,10 @@
 [CaseData]
-git-tree-sha1 = "a16b1305e3551c8426465545491883a0da9be61d"
+git-tree-sha1 = "4cf1aa00f73fcd77b6f2603c38f3e1eddb6e88fc"
 lazy = true
 
     [[CaseData.download]]
-    url = "https://github.com/Sienna-Platform/PowerSystemsTestData/archive/refs/tags/4.0.3.tar.gz"
-    sha256 = "2a9382d9a1b3a010191fb0c9bbac8011b345c484a4dadc0c38752f2e37726e9d"
+    url = "https://github.com/Sienna-Platform/PowerSystemsTestData/archive/refs/tags/4.0.4.tar.gz"
+    sha256 = "e02f3b62cc0ada5e82c2506665ca284d969bedecd1962137811854b54f97f80f"
 
 [rts]
 git-tree-sha1 = "c257b2c37b981f261fdc328b0fb9b96436a96537"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerSystemCaseBuilder"
 uuid = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
 authors = ["SIENNA TEAM"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1,5 +1,5 @@
 const PACKAGE_DIR = joinpath(dirname(dirname(pathof(PowerSystemCaseBuilder))))
-const DATA_DIR = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-4.0.3")
+const DATA_DIR = joinpath(LazyArtifacts.artifact"CaseData", "PowerSystemsTestData-4.0.4")
 
 const RTS_DIR = joinpath(LazyArtifacts.artifact"rts", "RTS-GMLC-0.2.3")
 

--- a/src/system_descriptor_data.jl
+++ b/src/system_descriptor_data.jl
@@ -1455,6 +1455,20 @@ const SYSTEM_CATALOG = [
         build_function = build_pti,
     ),
     SystemDescriptor(;
+        name = "psse_controlled_tap_v33_test_system",
+        description = "PSSE v33 system with a voltage-controlling TapTransformer (exercises tap_limits, number_of_tap_positions, regulated_bus_number, voltage_setpoint)",
+        category = PSSEParsingTestSystems,
+        raw_data = joinpath(DATA_DIR, "psse_raw", "psse_controlled_tap_test_v33.raw"),
+        build_function = build_pti,
+    ),
+    SystemDescriptor(;
+        name = "psse_controlled_tap_v35_test_system",
+        description = "PSSE v35 system with a voltage-controlling TapTransformer (exercises tap_limits, number_of_tap_positions, regulated_bus_number, voltage_setpoint)",
+        category = PSSEParsingTestSystems,
+        raw_data = joinpath(DATA_DIR, "psse_raw", "psse_controlled_tap_test_v35.raw"),
+        build_function = build_pti,
+    ),
+    SystemDescriptor(;
         name = "psse_14_zero_impedance_branch_test_system",
         description = "PSSE zero impedance branch test system",
         category = PSSEParsingTestSystems,


### PR DESCRIPTION
## Summary
Adds two `SystemDescriptor` entries to the catalog for PSSE systems containing a voltage-controlling `TapTransformer`:

- `psse_controlled_tap_v33_test_system` (PSSE v33)
- `psse_controlled_tap_v35_test_system` (PSSE v35)

These exercise `tap_limits`, `number_of_tap_positions`, `regulated_bus_number`, and `voltage_setpoint` on the parsed transformer.

Also adds Claude-related entries to `.gitignore`.

## Notes
Both descriptors reference raw files under `DATA_DIR/psse_raw/` (`psse_controlled_tap_test_v33.raw`, `psse_controlled_tap_test_v35.raw`), which must be present in the test data artifact for the systems to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)