### PR TITLE
Require PowerSystems 5.12 minimum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerSystemCaseBuilder"
 uuid = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
 authors = ["SIENNA TEAM"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -31,7 +31,7 @@ HDF5 = "0.17"
 InfrastructureSystems = "^3.2"
 JSON3 = "1"
 LazyArtifacts = "1"
-PowerSystems = "^5.10"
+PowerSystems = "^5.12"
 PrettyTables = "2.4, 3.1"
 Random = "1"
 SHA = "0.7"


### PR DESCRIPTION
Raises the PowerSystems compat lower bound to `^5.12` now that PSY 5.12.0 is registered, and bumps the package version to 2.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)