### PR TITLE
Format HVDC 14-bus builder kwargs

### DIFF
--- a/src/library/psitest_library.jl
+++ b/src/library/psitest_library.jl
@@ -136,7 +136,12 @@ function _replace_2_3_line_with_hvdc!(sys::PSY.System, converter)
     return sys
 end
 
-function build_c_sys14_hvdc_vsc(; add_forecasts, add_single_time_series, raw_data, kwargs...)
+function build_c_sys14_hvdc_vsc(;
+    add_forecasts,
+    add_single_time_series,
+    raw_data,
+    kwargs...,
+)
     sys_kwargs = filter_kwargs(; kwargs...)
     nodes = nodes14()
     c_sys14_hvdc_vsc = PSY.System(
@@ -201,7 +206,12 @@ function build_c_sys14_hvdc_vsc(; add_forecasts, add_single_time_series, raw_dat
     return c_sys14_hvdc_vsc
 end
 
-function build_c_sys14_hvdc_lcc(; add_forecasts, add_single_time_series, raw_data, kwargs...)
+function build_c_sys14_hvdc_lcc(;
+    add_forecasts,
+    add_single_time_series,
+    raw_data,
+    kwargs...,
+)
     sys_kwargs = filter_kwargs(; kwargs...)
     nodes = nodes14()
     c_sys14_hvdc_lcc = PSY.System(


### PR DESCRIPTION
Runs the repo formatter over `src/library/psitest_library.jl`. The `build_c_sys14_hvdc_vsc` and `build_c_sys14_hvdc_lcc` builders (added with the HVDC 14-bus cases) had over-width keyword signatures that fail the Format Check CI on `main`. This wraps them to satisfy JuliaFormatter.

The Main-CI and Documentation jobs on this PR will remain red until the pkg-server General registry snapshot picks up PowerSystems 5.12.0 (already merged to the General registry; pkg-server propagation is lagging).